### PR TITLE
fix package error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -200,7 +200,7 @@ ac_add_options --enable-optimize=-O3
 # Features
 ac_add_options --enable-alsa
 ac_add_options --enable-jack
-ac_add_options --enable-crashreporter
+ac_add_options --disable-crashreporter
 ac_add_options --disable-updater
 ac_add_options --disable-tests
 
@@ -306,12 +306,7 @@ ObjectPath=/org/mozilla/${_pkgname//-/}/SearchProvider
 Version=2
 END
 
-  export SOCORRO_SYMBOL_UPLOAD_TOKEN_FILE="$startdir/.crash-stats-api.token"
-  if [[ -f $SOCORRO_SYMBOL_UPLOAD_TOKEN_FILE ]]; then
-    make -C obj uploadsymbols
-  else
-    cp -fvt "$startdir" obj/dist/*crashreporter-symbols-full.tar.zst
-  fi
+
 }
 
 # vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
Crash reporter fails at the packaging step. shouldnt be reporting crashes on custom build firefox anyway so just disable the reporter and cleanup the packaging step that fails.